### PR TITLE
fix: scope tsconfig to src/ and add PR CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm run unit-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the ALCops extension will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Scope `tsconfig.json` to `src/` via `include` and add explicit `types: ["node"]` to fix TS6059 errors from test files outside `rootDir`
+
+### Added
+- Add CI workflow (`.github/workflows/ci.yml`) to run lint, typecheck, and unit tests on pull requests
+
 ## [1.3.0] - 2026-04-17
 
 ### Added

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,12 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
+		"types": ["node"],
 		"strict": true,   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
-	}
+	},
+	"include": ["src"]
 }


### PR DESCRIPTION
- Add "include": ["src"] to tsconfig.json to prevent TS6059 errors from test files and vitest.config.ts outside rootDir
- Add explicit "types": ["node"] since narrowing include broke TypeScript 6.x auto-discovery of @types/node
- Add .github/workflows/ci.yml to run lint, typecheck, and unit tests on pull requests targeting main and release branches