### PR TITLE
fix: restructure CI into DRY pattern and fix engines.vscode mismatch

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -12,7 +12,13 @@ permissions:
   contents: write
 
 jobs:
-  build-and-release:
+  build-and-test:
+    uses: ./.github/workflows/build-test.yml
+    with:
+      draft-check: false
+
+  release:
+    needs: build-and-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -37,23 +43,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Type check
-        run: npm run typecheck
-
-      - name: Unit tests
-        run: npm run unit-test
-
       - name: Update version in package.json
         run: |
           npm version ${{ steps.gitversion.outputs.semVer }} --no-git-tag-version
 
       - name: Package extension
         run: |
-          npm install -g @vscode/vsce
-          vsce package --no-git-tag-version -o alcops-${{ steps.gitversion.outputs.semVer }}.vsix
+          npx vsce package --no-git-tag-version -o alcops-${{ steps.gitversion.outputs.semVer }}.vsix
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -69,4 +65,4 @@ jobs:
       - name: Publish to VS Code Marketplace
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          vsce publish -p ${{ secrets.VISUAL_STUDIO_MARKETPLACE_PAT }} --packagePath ./alcops-${{ steps.gitversion.outputs.semVer }}.vsix
+          npx vsce publish -p ${{ secrets.VISUAL_STUDIO_MARKETPLACE_PAT }} --packagePath ./alcops-${{ steps.gitversion.outputs.semVer }}.vsix

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,13 +1,18 @@
-name: CI
+name: Build and Test
 
 on:
-  pull_request:
-    branches:
-      - main
-      - "release/**"
+  workflow_call:
+    inputs:
+      draft-check:
+        description: "Whether to check if PR is draft"
+        required: false
+        type: boolean
+        default: true
+  workflow_dispatch:
 
 jobs:
-  ci:
+  build-and-test:
+    if: ${{ !inputs.draft-check || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -29,3 +34,6 @@ jobs:
 
       - name: Unit tests
         run: npm run unit-test
+
+      - name: Package validation
+        run: npx vsce package --no-git-tag-version

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,16 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/build-test.yml
+    with:
+      draft-check: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the ALCops extension will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Update `engines.vscode` from `^1.110.0` to `^1.116.0` to match `@types/vscode`, fixing `vsce package` build failure
+
+### Changed
+- Restructure CI into DRY pattern: extract shared `build-test.yml` reusable workflow, rename `ci.yml` to `pull-request.yml`, and have `build-and-release.yml` reuse `build-test.yml` (matching `ALCops/Analyzers` repo pattern)
+- Add `vsce package` validation step to CI to catch `@types/vscode` vs `engines.vscode` mismatches on pull requests before merge
+- Use `npx vsce` instead of global `npm install -g @vscode/vsce` in build-and-release workflow
+
 ## [1.3.0] - 2026-04-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "code-quality"
   ],
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.116.0"
   },
   "categories": [
     "Linters"


### PR DESCRIPTION
- Update engines.vscode from ^1.110.0 to ^1.116.0 to match @types/vscode
- Extract shared build-test.yml reusable workflow (workflow_call) with lint, typecheck, unit tests, and vsce package validation
- Rename ci.yml to pull-request.yml, calling build-test.yml
- Restructure build-and-release.yml to reuse build-test.yml and use npx vsce instead of global install
- Matches ALCops/Analyzers repo DRY pattern