### PR TITLE
feat: add IntelliSense for alcops.json settings files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the ALCops extension will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-04-22
+
+### Added
+- IntelliSense support for `alcops.json` settings files (autocompletion, validation, documentation) via JSON Schema hosted in the Analyzers repository
+
 ## [1.3.0] - 2026-04-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -51,6 +51,15 @@
         "title": "ALCops: Select Code Analyzers"
       }
     ],
+    "jsonValidation": [
+      {
+        "fileMatch": [
+          "alcops.json",
+          "ALCops.json"
+        ],
+        "url": "https://raw.githubusercontent.com/ALCops/Analyzers/main/src/ALCops.Common/Settings/alcops.schema.json"
+      }
+    ],
     "configuration": {
       "title": "ALCops",
       "properties": {


### PR DESCRIPTION
## Summary

Add JSON Schema-based IntelliSense for `alcops.json` configuration files, giving users autocompletion, validation, and inline documentation when editing analyzer settings.

## Changes

- **`package.json`** — Add `contributes.jsonValidation` entry matching `alcops.json` and `ALCops.json` (case variants for Linux), pointing to the schema hosted in the Analyzers repo
- **`CHANGELOG.md`** — Add entry under `[Unreleased]` > Added

## How it works

VS Code's built-in JSON Language Features fetch the schema from:
```
https://raw.githubusercontent.com/ALCops/Analyzers/main/src/ALCops.Common/Settings/alcops.schema.json
```

No runtime code changes needed. This is purely a declarative `package.json` contribution.

## Dependencies

⚠️ **Merge [ALCops/Analyzers#207](https://github.com/ALCops/Analyzers/pull/207) first** — that PR adds the schema file. Until it's merged to `main`, the raw URL returns 404.