### PR TITLE
fix: support AL 18 flat bin layout for analyzer installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the ALCops extension will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-08-20
+
+### Fixed
+- Fix "DLL file not found" installation failure on AL Language extension 18+ (BC 29), which moved all DLLs from `bin/Analyzers/` directly into `bin/`. The analyzers folder is now detected by probing for `Microsoft.Dynamics.Nav.CodeAnalysis.dll` (flat `bin/` layout first, legacy `bin/Analyzers/` as fallback) ([ALCops/Analyzers#442](https://github.com/ALCops/Analyzers/discussions/442))
+
 ## [1.3.4] - 2026-05-09
 
 ### Added

--- a/src/al-extension-handler.ts
+++ b/src/al-extension-handler.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 import { checkDirectoryForLockedFiles } from './file-lock-handler.js';
+import { resolveAnalyzersDir } from './analyzers-layout.js';
 
 const AL_EXTENSION_ID = 'ms-dynamics-smb.al';
 
@@ -12,12 +12,14 @@ export function getALExtension(): vscode.Extension<any> | null {
 }
 
 /**
- * Get the path to the Analyzers folder inside the AL extension.
- * Returns null if the AL extension is not installed.
+ * Get the path to the folder where analyzer DLLs live inside the AL extension.
+ * Handles both the flat `bin` layout (AL 18+) and the legacy `bin/Analyzers`
+ * layout (AL <=17). Returns null if the AL extension is not installed or the
+ * layout could not be determined.
  */
 export function getAnalyzersPath(): string | null {
     const ext = getALExtension();
-    return ext ? path.join(ext.extensionPath, 'bin', 'Analyzers') : null;
+    return ext ? resolveAnalyzersDir(ext.extensionPath) : null;
 }
 
 interface ALExtensionStatus {

--- a/src/analyzers-layout.ts
+++ b/src/analyzers-layout.ts
@@ -1,0 +1,41 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * The AL compiler DLL used to detect both the analyzers folder layout
+ * and the target .NET framework of the AL Language extension.
+ */
+export const CODE_ANALYSIS_DLL = 'Microsoft.Dynamics.Nav.CodeAnalysis.dll';
+
+/**
+ * Resolve the directory where analyzer DLLs live inside the AL Language extension.
+ *
+ * AL 18+ (BC 29) ships a flat layout: all DLLs (including the compiler and
+ * Microsoft analyzers) sit directly in `bin/`. AL <=17 uses the legacy layout
+ * with a `bin/Analyzers/` subfolder.
+ *
+ * Detection probes for Microsoft.Dynamics.Nav.CodeAnalysis.dll, flat layout
+ * first. This is unambiguous: legacy versions never place the DLL directly in
+ * `bin/`, and probing avoids brittle version thresholds or folder-existence
+ * checks (an empty `bin/Analyzers/` folder may exist on flat layouts).
+ *
+ * @param alExtensionPath Root path of the installed AL Language extension
+ * @returns The directory containing the CodeAnalysis DLL, or null if not found
+ */
+export function resolveAnalyzersDir(alExtensionPath: string): string | null {
+    for (const candidate of getAnalyzersDirCandidates(alExtensionPath)) {
+        if (fs.existsSync(path.join(candidate, CODE_ANALYSIS_DLL))) {
+            return candidate;
+        }
+    }
+    return null;
+}
+
+/**
+ * Candidate analyzer directories in probe order: flat `bin/` (AL 18+) first,
+ * legacy `bin/Analyzers/` (AL <=17) as fallback.
+ */
+export function getAnalyzersDirCandidates(alExtensionPath: string): string[] {
+    const binPath = path.join(alExtensionPath, 'bin');
+    return [binPath, path.join(binPath, 'Analyzers')];
+}

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -12,6 +12,7 @@ import { readManifest, writeManifest, createManifest, markAsPendingUpdate, clear
 import { checkDirectoryForLockedFiles } from './file-lock-handler.js';
 import { stageAndReplaceFiles, cleanupOldBackups } from './file-staging.js';
 import { getALExtension, promptUserForLockedFiles } from './al-extension-handler.js';
+import { resolveAnalyzersDir, getAnalyzersDirCandidates, CODE_ANALYSIS_DLL } from './analyzers-layout.js';
 import { launchNewVSCodeWindow } from './vscode-launcher.js';
 import { formatError, showTimedMessage } from './utils.js';
 
@@ -253,8 +254,11 @@ async function downloadALCopsAnalyzersInternal(version: string): Promise<void> {
             throw new Error('AL extension (ms-dynamics-smb.al) is not installed');
         }
 
-        const targetPath = path.join(alExtension.extensionPath, 'bin', 'Analyzers');
-        fs.mkdirSync(targetPath, { recursive: true });
+        const targetPath = resolveAnalyzersDir(alExtension.extensionPath);
+        if (!targetPath) {
+            const probed = getAnalyzersDirCandidates(alExtension.extensionPath).join(', ');
+            throw new Error(`Could not locate ${CODE_ANALYSIS_DLL} in the AL extension. Probed: ${probed}`);
+        }
 
         // Download and extract to a temp directory
         tempDir = path.join(os.tmpdir(), `alcops-temp-${Date.now()}`);
@@ -383,7 +387,7 @@ function extractZip(zipPath: string, extractPath: string): Promise<void> {
  * Extract the target framework from the Microsoft.Dynamics.Nav.CodeAnalysis.dll file
  */
 async function getTargetFramework(dllPath: string): Promise<string> {
-    const dllFile = path.join(dllPath, 'Microsoft.Dynamics.Nav.CodeAnalysis.dll');
+    const dllFile = path.join(dllPath, CODE_ANALYSIS_DLL);
 
     if (!fs.existsSync(dllFile)) {
         throw new Error(`DLL file not found: ${dllFile}`);

--- a/src/status-bar-manager.ts
+++ b/src/status-bar-manager.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 import { CodeAnalyzersManager } from './code-analyzers-manager.js';
+import { getAnalyzersPath } from './al-extension-handler.js';
 import { showTimedMessage } from './utils.js';
 
 export class StatusBarManager {
@@ -15,16 +15,11 @@ export class StatusBarManager {
             100 // High priority to show it early
         );
 
-        // Initialize Code Analyzers Manager with AL extension path
+        // Initialize Code Analyzers Manager with the AL extension's analyzers path
         try {
-            const alExtension = vscode.extensions.getExtension('ms-dynamics-smb.al');
-            if (alExtension) {
-                const analyzerPath = path.join(alExtension.extensionPath, 'bin', 'Analyzers');
-                this.codeAnalyzersManager = new CodeAnalyzersManager(analyzerPath);
-            } else {
-                // Initialize with default analyzers
-                this.codeAnalyzersManager = new CodeAnalyzersManager('');
-            }
+            const analyzerPath = getAnalyzersPath();
+            // Fall back to default analyzers when the path cannot be resolved
+            this.codeAnalyzersManager = new CodeAnalyzersManager(analyzerPath ?? '');
         } catch (error) {
             // Initialize with default analyzers even if error occurs
             this.codeAnalyzersManager = new CodeAnalyzersManager('');

--- a/tests/analyzers-layout.test.ts
+++ b/tests/analyzers-layout.test.ts
@@ -1,0 +1,69 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { resolveAnalyzersDir, getAnalyzersDirCandidates, CODE_ANALYSIS_DLL } from '../src/analyzers-layout.js';
+
+describe('resolveAnalyzersDir', () => {
+    let tempDir: string;
+    let binPath: string;
+    let legacyPath: string;
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alcops-layout-test-'));
+        binPath = path.join(tempDir, 'bin');
+        legacyPath = path.join(binPath, 'Analyzers');
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    function placeDll(dir: string): void {
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, CODE_ANALYSIS_DLL), 'stub');
+    }
+
+    it('returns bin for the flat layout (AL 18+)', () => {
+        placeDll(binPath);
+        expect(resolveAnalyzersDir(tempDir)).toBe(binPath);
+    });
+
+    it('returns bin/Analyzers for the legacy layout (AL <=17)', () => {
+        placeDll(legacyPath);
+        expect(resolveAnalyzersDir(tempDir)).toBe(legacyPath);
+    });
+
+    it('prefers the flat layout when the DLL exists in both locations', () => {
+        placeDll(binPath);
+        placeDll(legacyPath);
+        expect(resolveAnalyzersDir(tempDir)).toBe(binPath);
+    });
+
+    it('returns bin when an empty Analyzers folder exists alongside a flat DLL', () => {
+        // Real-world AL 18 state: an empty bin/Analyzers left behind by older installs
+        placeDll(binPath);
+        fs.mkdirSync(legacyPath, { recursive: true });
+        expect(resolveAnalyzersDir(tempDir)).toBe(binPath);
+    });
+
+    it('returns null when the DLL exists in neither location', () => {
+        fs.mkdirSync(legacyPath, { recursive: true });
+        expect(resolveAnalyzersDir(tempDir)).toBeNull();
+    });
+
+    it('returns null when the bin folder does not exist', () => {
+        expect(resolveAnalyzersDir(tempDir)).toBeNull();
+    });
+});
+
+describe('getAnalyzersDirCandidates', () => {
+    it('probes flat bin first, then legacy bin/Analyzers', () => {
+        const root = path.join('C:', 'ext', 'al');
+        expect(getAnalyzersDirCandidates(root)).toEqual([
+            path.join(root, 'bin'),
+            path.join(root, 'bin', 'Analyzers'),
+        ]);
+    });
+});


### PR DESCRIPTION
## Problem

Installing ALCops on AL Language extension 18+ (BC 29) fails with:

```
Failed to install ALCops: DLL file not found: ...\bin\Analyzers\Microsoft.Dynamics.Nav.CodeAnalysis.dll
```

Starting with BC 29 / AL 18, the VSIX no longer contains `bin/Analyzers/` (or the platform subfolders). All DLLs, including `Microsoft.Dynamics.Nav.CodeAnalysis.dll`, sit flat in `bin/`. See ALCops/Analyzers#442; the same root cause was fixed for CI tooling in ALCops/Analyzers#439.

The extension hardcoded `bin/Analyzers` in three places (`downloader.ts`, `al-extension-handler.ts`, `status-bar-manager.ts`). The downloader also eagerly created the folder before validation, leaving stray empty `bin/Analyzers` folders on AL 18 installs.

## Fix

Candidate-path layout detection (same strategy as ALCops/Analyzers#439): probe for `Microsoft.Dynamics.Nav.CodeAnalysis.dll` in `bin/` (flat, AL 18+) first, then `bin/Analyzers/` (legacy, AL <=17). Unambiguous: legacy versions never ship the DLL flat in `bin/`. No version thresholds, no folder-existence checks.

- New pure module `src/analyzers-layout.ts` with `resolveAnalyzersDir()`; all call sites route through it
- Removed the eager `mkdirSync`; unresolvable layout now throws a clear error naming both probed paths
- Flat installs place ALCops DLLs and `.alcops-manifest.json` directly in `bin/` (safe: lock checks and staging are manifest/source-scoped)
- `${analyzerFolder}` in `al.codeAnalyzers` resolves correctly in both layouts, no settings changes needed (manually verified on 17.0.2273547 and 18.0.2668733)

## Validation

- `npm run lint`, `npm run typecheck`: clean
- `npm run unit-test`: 38/38 passed, including 7 new tests for the resolver (flat, legacy, both present, neither, and the real-world "empty Analyzers folder + flat DLL" state)
